### PR TITLE
chore: 更新依赖文件，区分Windows和macOS特定依赖

### DIFF
--- a/documents/docs/guide/系统依赖安装.md
+++ b/documents/docs/guide/系统依赖安装.md
@@ -2,13 +2,14 @@
 
 ## 概述
 
-本文档提供py-xiaozhi项目的完整依赖安装指南，包括系统级依赖和Python环境配置。请按照文档顺序进行安装。
+本文档提供 **py-xiaozhi** 项目的依赖安装指南：系统级运行库 + Python 环境。**建议先装“最小系统依赖”，再用 pip/venv 或 conda 安装 Python 包**，最后按需打包。
 
-## 系统依赖安装
+---
 
 ### Windows
 
 #### 多媒体组件
+
 ```bash
 # 使用 Scoop 安装（推荐）
 scoop install ffmpeg
@@ -17,58 +18,154 @@ scoop install ffmpeg
 conda install -c conda-forge ffmpeg opus
 ```
 
-#### 手动安装FFmpeg
-1. 下载：[BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds/releases)
-2. 解压后将`bin`目录添加至系统环境变量`PATH`
+#### 手动安装 FFmpeg
 
-#### Opus音频编解码器
-- 项目已包含`opus.dll`，通常无需额外安装
-- 如遇问题，可将`/libs/windows/opus.dll`复制到：
-  - 应用程序运行目录
-  - `C:\Windows\System32`
+1. 下载：BtbN/FFmpeg-Builds（Releases）
+2. 解压后将 `bin` 目录添加至系统环境变量 `PATH`
 
-### Linux (Debian/Ubuntu)
+#### Opus 音频编解码器
 
-#### 核心依赖
+* 项目已包含 `opus.dll`，通常无需额外安装
+* 如遇问题，可将 `/libs/windows/opus.dll` 复制到：
+
+  * 应用程序运行目录
+  * `C:\Windows\System32`
+
+---
+
+### Linux（Ubuntu，仅）
+
+> 适用范围：Ubuntu 20.04/22.04/24.04/25.04，架构含 x86_64 与 ARM64（树莓派官方 Ubuntu 镜像）。Raspberry Pi OS 不在本指南覆盖范围。
+
+#### 快速开始（先系统依赖，后 Python 依赖）
+
 ```bash
-# 更新包管理器
-sudo apt-get update
+sudo apt update
 
-# 安装核心依赖
-sudo apt-get install portaudio19-dev ffmpeg libopus0 libopus-dev \
-                     build-essential python3-venv python3-pip \
-                     libasound2-dev
+# 最小系统运行库（x86_64/arm64 通用）
+sudo apt install -y \
+  build-essential python3-venv python3-pip pkg-config \
+  ffmpeg libopus0 libopus-dev \
+  espeak-ng
+
+# 音频后端（PortAudio + ALSA 必装；JACK 二选一）
+sudo apt install -y libportaudio2 portaudio19-dev \
+                    libasound2 libasound2-data libasound2-dev
+
+# Ubuntu 24.04/25.04（默认 PipeWire）：推荐装 PipeWire 的 JACK 兼容层
+sudo apt install -y pipewire-jack
+
+# 如果你明确需要“原生 JACKd2”，则改为（与上面 pipewire-jack 互斥，勿共存）：
+# sudo apt install -y libjack-jackd2-0
+# 旧版本（20.04/22.04）也可使用：
+# sudo apt install -y libjack0
+
+# GUI/Qt/SDL 运行时（使用 GUI 或 pygame 时推荐）
+sudo apt install -y \
+  libx11-xcb1 libxkbcommon-x11-0 \
+  libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 \
+  libxcb-shape0 libxcb-xinerama0 \
+  libgl1 libegl1 \
+  libsdl2-2.0-0
 ```
 
-#### 音频系统依赖（选择其一）
+> JACK / PipeWire 说明（按需二选一，不要同时安装）：
+>
+> * Ubuntu 24.04/25.04（默认 PipeWire）：推荐 `pipewire-jack`（PipeWire 的 JACK 兼容层），多数只需要 `libjack.so.0` 的程序即可工作。
+>
+>   ```bash
+>   sudo apt install -y pipewire-jack
+>   ```
+>
+> * 如需原生 jackd2：可改装 `libjack-jackd2-0`（与 `pipewire-jack` 互斥，勿共存）。
+>
+>   ```bash
+>   sudo apt install -y libjack-jackd2-0
+>   ```
+>
+> Ubuntu 23.04 起默认音频栈迁移到 PipeWire；22.04 默认 PulseAudio（可手动启用 PipeWire）。
 
-**PulseAudio（推荐）**
+说明：
+
+* 纯 CLI 模式可跳过“GUI/Qt/SDL 运行时”。
+* 上述依赖覆盖 PortAudio/JACK/ALSA、XCB/GL/SDL、TTS 等常见缺项。`portaudio19-dev` 在 22.04/24.04/25.04（含 arm64）均有官方包。
+
+接着，在 Python 依赖层 **二选一**：
+
+* **路线 A：系统 Python + venv + pip（不使用 conda）**
+
+  ```bash
+  python3 -m venv .venv
+  source .venv/bin/activate
+  pip install -U pip
+  pip install -r requirements.txt
+  ```
+
+* **路线 B：conda/conda-forge（在 aarch64/树莓派上更稳）**
+
+  ```bash
+  conda create -n py-xiaozhi python=3.10 -y
+  conda activate py-xiaozhi
+  conda config --env --add channels conda-forge
+  conda config --env --set channel_priority strict
+  # 二进制相关优先用 conda（示例，可按需裁剪）
+  conda install -y pyqt numpy opencv pygame portaudio jack python-sounddevice pillow psutil cryptography soxr
+  # 纯 Python 包再用 pip
+  pip install openai paho-mqtt pyperclip pypinyin requests websockets colorlog qasync \
+              py-machineid mutagen beautifulsoup4 python-dateutil packaging rich lunar_python opuslib
+  ```
+
+> 说明：conda 用户优先用 conda-forge 安装**带本地二进制**的包（如 pyqt/sounddevice/portaudio/jack/opencv），再用 pip 补充纯 Python 包，能显著降低 ABI 冲突概率。
+
+#### PyQt 安装（仅三选一，**切勿混用**）
+
+* **pip 版（版本可控，适合 venv/conda）**
+
+  ```bash
+  # 不要同时装 apt 的 python3-pyqt5，避免冲突
+  # 注：在 ARM64 上，pip 的 PyQt5 轮子经常不可用/需源码构建，优先使用 conda-forge。
+  pip install PyQt5==5.15.11 qasync
+  ```
+
+  （社区多次反馈 ARM64 pip 安装 PyQt5 轮子缺失或需源码构建；conda-forge 往往更稳。）
+
+* **conda 版（conda-forge，更稳）**
+
+  ```bash
+  conda install -c conda-forge -y pyqt qasync
+  ```
+
+> **防踩坑**：pip 或 conda 任一生态安装 PyQt 即可，**不要混装**（避免 xcb/运行库冲突）。
+
+#### Ubuntu 版本与 Python 版本
+
+* 项目要求 Python：**3.9.13+（推荐 3.10，最高 3.11）**。
+* Ubuntu 24.04 默认 **Python 3.12**；Ubuntu 25.04 默认 **Python 3.13**。请使用 conda/pyenv/源码安装所需版本到**项目环境**，**不要修改系统 `/usr/bin/python3` 指向**。
+
+#### 验证步骤
+
 ```bash
-sudo apt-get install pulseaudio-utils
+# 1) PortAudio 链路 OK（能列出设备数量）
+python -c "import sounddevice as sd; print(sd.get_portaudio_version()); print(len(sd.query_devices()))"
+
+# 2) TTS 可用
+espeak-ng --version || which espeak
+
+# 3) PyQt 加载（如需 GUI）
+python - <<'PY'
+import PyQt5, PyQt5.QtCore as QC
+print('PyQt5 路径:', PyQt5.__file__)
+print('Qt 版本:', QC.QT_VERSION_STR)
+PY
 ```
 
-**ALSA音频系统**
-```bash
-sudo apt-get install alsa-utils
-```
+#### PyInstaller 打包提示（Linux）
 
-**ALSA + 交互工具**
-```bash
-sudo apt-get install alsa-utils expect
-```
+* **会打包**：Python 解释器、PyQt 自带的 Qt 库与插件、纯/扩展模块的 `.so`。
+* **不会/不应打包**：ALSA/JACK/PulseAudio、X11/xcb/GL、`glibc`/`libstdc++.so.6`、`espeak-ng` 等**系统运行库/服务** → 需按“最小系统依赖”提前安装。
+* **无显示环境**可用无头：`QT_QPA_PLATFORM=offscreen`（仅限无需显示窗口的场景）。
 
-#### GUI支持
-```bash
-# PyQt5 GUI依赖
-sudo apt-get install python3-pyqt5 python3-pyqt5.qtmultimedia \
-                     qtbase5-dev qt5-qmake qtmultimedia5-dev
-```
-
-#### 开发工具（可选）
-```bash
-# 编译依赖
-sudo apt-get install gcc g++ make cmake pkg-config
-```
+---
 
 ### macOS
 
@@ -81,44 +178,32 @@ brew upgrade tcl-tk
 xcode-select --install
 ```
 
-## Python环境配置
+---
 
-### 方式一：使用Miniconda（推荐）
+## Python 环境配置
 
-#### 1. 下载Miniconda
+### 方式一：使用 Miniconda（推荐）
 
-| 操作系统 | 架构 | 下载命令 |
-|---------|------|----------|
-| **Linux** | x86_64 | `wget -O Miniconda3-latest-Linux-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh` |
-| **Linux** | ARM64 | `wget -O Miniconda3-latest-Linux-aarch64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh` |
-| **macOS** | Intel | `wget -O Miniconda3-latest-MacOSX-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh` |
-| **macOS** | Apple Silicon | `wget -O Miniconda3-latest-MacOSX-arm64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh` |
-| **Windows** | x86_64 | [下载链接](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe) |
+（从官方按系统/架构下载最新版安装器）
 
-#### 2. 安装Miniconda
+#### 2. 安装 Miniconda（Linux/macOS）
 
-**Linux/macOS**
 ```bash
-# 添加执行权限
 chmod +x Miniconda3-latest-*.sh
-
-# 运行安装程序
 ./Miniconda3-latest-*.sh
 ```
 
-安装过程中的选择：
-1. 许可协议：按`Enter`或`q`跳过，输入`yes`接受
-2. 安装路径：使用默认路径（推荐）
-3. 初始化：输入`yes`（推荐）
+安装过程：
+
+1. 许可协议：`yes` 接受
+2. 安装路径：默认（推荐）
+3. 初始化：`yes`（推荐）
 
 #### 3. 配置环境（如需要）
 
 ```bash
-# 如环境变量未自动配置
 echo 'export PATH="$HOME/miniconda3/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
-
-# 初始化conda
 conda init
 ```
 
@@ -131,65 +216,62 @@ conda --version
 #### 5. 优化配置
 
 ```bash
-# 关闭自动激活base环境
 conda config --set auto_activate_base false
-
-# 添加conda-forge频道
 conda config --add channels conda-forge
 ```
 
-### 方式二：使用系统Python + venv
+### 方式二：使用系统 Python + venv
 
 ```bash
-# 创建虚拟环境
 python3 -m venv .venv
-
-# 激活虚拟环境
 # Linux/macOS
 source .venv/bin/activate
 # Windows
 .venv\Scripts\activate
 ```
 
+---
+
 ## 包管理器优化
 
 ### 换源工具（推荐）
 
 ```bash
-# Windows（PowerShell管理员权限）
+# Windows（PowerShell 管理员权限）
 winget install RubyMetric.chsrc --source winget
 
 # Linux/macOS
 wget -O- aslant.top/chsrc.sh | sudo bash
 
-# 配置pip源
+# 配置 pip 源
 chsrc set pip
 ```
 
-### 手动配置pip源
+### 手动配置 pip 源
 
 ```bash
-# 使用阿里云镜像源
 pip config set global.index-url https://mirrors.aliyun.com/pypi/simple/
 pip config set install.trusted-host mirrors.aliyun.com
 ```
+
+---
 
 ## 项目依赖安装
 
 ### 1. 创建项目环境
 
 ```bash
-# 使用Conda（推荐）
+# 使用 Conda（推荐）
 conda create -n py-xiaozhi python=3.10 -y
 conda activate py-xiaozhi
 
-# 或使用venv
+# 或使用 venv
 python3 -m venv .venv
 source .venv/bin/activate  # Linux/macOS
 # .venv\Scripts\activate   # Windows
 ```
 
-### 2. 安装Python依赖
+### 2. 安装 Python 依赖
 
 ```bash
 # Linux/Windows
@@ -202,82 +284,59 @@ pip install -r requirements_mac.txt
 ### 3. 验证安装
 
 ```bash
-# 检查关键依赖
 python -c "import sounddevice; print('SoundDevice OK')"
 python -c "import opuslib; print('Opus OK')"
 python -c "import PyQt5.QtCore; print('PyQt5 OK')"
 ```
 
+---
+
 ## 故障排除
 
 ### 常见问题
 
-#### SoundDevice安装失败
+#### SoundDevice 安装/加载失败
+
 ```bash
-# Ubuntu/Debian
-sudo apt-get install portaudio19-dev libasound2-dev
-
-# macOS
-brew install portaudio
-
-# Windows
-# SoundDevice通常可以直接通过pip安装
-pip install sounddevice
+# Ubuntu/Debian（PortAudio/ALSA 必备；JACK 视你的选择安装）
+sudo apt-get install -y portaudio19-dev libasound2-dev
+# 若需 JACK：
+# Ubuntu 24.04/25 优先：sudo apt-get install -y pipewire-jack
+# 或原生 jackd2：     sudo apt-get install -y libjack-jackd2-0
 ```
 
-#### PyQt5安装失败
-```bash
-# Ubuntu/Debian
-sudo apt-get install python3-pyqt5 qtbase5-dev
+#### PyQt5 安装冲突 / xcb 插件报错
 
-# macOS
-brew install pyqt5
+* **pip / conda 二选一，勿混装**。
+* 缺少 xcb/GL 运行库时，用“最小系统依赖”一键补齐。
+* **ARM64** 若 pip 安装 PyQt5 失败，优先改用 **conda-forge**。
 
-# Windows
-# PyQt5通常可以直接通过pip安装
-pip install PyQt5
-```
+#### `GLIBCXX_3.4.32 not found`（多见于 conda 与 pip 二进制包混用）
 
-#### Opus库缺失
-- macos用户请使用conda安装，不然得自行解决软连接
-```bash
-# 使用conda安装
-conda install -c conda-forge opus
-# 软连接
-nano ~/.zshrc 
-export DYLD_LIBRARY_PATH=/opt/homebrew/lib:$DYLD_LIBRARY_PATH
-source ~/.zshrc 
+* 解决思路（择一）：
 
-# 或检查系统库
-# Linux
-sudo apt-get install libopus0 libopus-dev
-# macOS
-brew install opus
-```
+  * **全用 conda-forge** 安装二进制相关包（pyqt / numpy / sounddevice / portaudio / jack）。
+  * **或**仅用系统库 + venv + pip（先装“最小系统依赖”）。
+* 临时诊断：
 
-#### 权限问题（Linux）
-```bash
-# 将用户添加到audio组
-sudo usermod -a -G audio $USER
+  ```bash
+  LD_DEBUG=libs python -c "import sounddevice" 2>&1 | grep -E "libstdc\+\+\.so\.6|libportaudio|libjack"
+  strings /usr/lib/aarch64-linux-gnu/libstdc++.so.6 | grep GLIBCXX_3.4.32 || echo "系统库缺该符号"
+  ```
 
-# 重新登录后生效
-```
+#### JACK / PipeWire 冲突
+
+* **`pipewire-jack` 与原生 `jackd2` 互斥**：24.04+ 推荐 `pipewire-jack`；如改用原生 JACK，请先卸载 `pipewire-jack`，避免 `libjack.so.0` 冲突。
+
+---
 
 ## 版本要求
 
-- **Python**: 3.9.13+ (推荐3.10，最高3.11)
-- **PyQt5**: 5.15+
-- **SoundDevice**: 0.4.4+
-- **FFmpeg**: 4.0+
-- **Opus**: 1.3+
-- **PortAudio**: 19.0+
+* **Python**: 3.9.13+（推荐 3.10，最高 3.11）
+* **PyQt5**: 5.15+
+* **SoundDevice**: 0.4.4+
+* **FFmpeg**: 4.0+
+* **Opus**: 1.3+
+* **PortAudio**: 19.0+
 
-## 注意事项
-
-1. 建议使用Conda环境管理依赖
-2. 不要与esp32-server共用Conda环境
-3. macOS用户必须使用`requirements_mac.txt`
-4. Windows用户无需手动安装opus.dll
-5. 项目使用SoundDevice替代PyAudio，使用PyQt5作为GUI框架
-6. 确保系统依赖安装完成后再安装Python依赖
-7. 使用国内镜像源可提高下载速度
+> Ubuntu 24.04 默认 Python 3.12；25.04 默认 Python 3.13。请**不要修改系统 python3 软链接**，用 conda/pyenv/源码在项目环境中使用目标版本。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,35 +1,39 @@
-comtypes==1.4.6
+# Windows-only
+comtypes==1.4.6; sys_platform == "win32"
+pycaw==20240210; sys_platform == "win32"
+
+# 二进制/系统库敏感
 cryptography==44.0.1
 numpy==1.26.4
+sounddevice>=0.4.4
+pygame==2.6.1
+PyQt5==5.15.11
+opencv-python-headless==4.11.0.86
+soxr==0.5.0.post1
+psutil==7.0.0
+pillow==11.3.0
+webrtcvad-wheels==2.0.14
+sherpa-onnx==1.12.8
+pendulum==3.1.0
+
+# 纯 Python 为主
 openai==1.86.0
 opuslib==3.0.1
 paho-mqtt==2.1.0
-psutil==7.0.0
-sounddevice>=0.4.4
-pycaw==20240210
 pynput==1.8.1
 pyperclip==1.9.0
 pypinyin==0.53.0
-requests==2.32.3
 aiohttp==3.12.13
-webrtcvad-wheels==2.0.14
 websockets==11.0.3
 colorlog==6.9.0
-pygame==2.6.1
 qasync==0.27.1
 py-machineid==0.8.0
-soxr==0.5.0.post1
 mutagen==1.47.0
 beautifulsoup4==4.12.3
 brotli==1.1.0
 python-dateutil==2.9.0.post0
-PyQt5==5.15.11
-opencv-python-headless==4.11.0.86
-pendulum==3.1.0
 lunar_python==1.4.4
-sherpa-onnx==1.12.8
 pyinstaller==6.15.0
 rich==14.1.0
-requests==2.32.3
 packaging==25.0
-pillow==11.3.0
+requests==2.32.3

--- a/requirements_mac.txt
+++ b/requirements_mac.txt
@@ -1,37 +1,42 @@
-applescript==2021.2.9  # macOS音量控制
-comtypes==1.4.6
+# Windows-only
+comtypes==1.4.6; sys_platform == "win32"
+pycaw==20240210; sys_platform == "win32"
+
+# macOS-only
+applescript==2021.2.9; sys_platform == "darwin"  # macOS音量控制
+
+# 二进制/系统库敏感
 cryptography==44.0.1
 numpy==1.26.4
+sounddevice>=0.4.4
+pygame==2.6.1
+PyQt5==5.15.11
+opencv-python-headless==4.11.0.86
+soxr==0.5.0.post1
+psutil==7.0.0
+pillow==11.3.0
+webrtcvad-wheels==2.0.14
+sherpa-onnx==1.12.8
+pendulum==3.1.0
+
+# 纯 Python 为主
 openai==1.86.0
 opuslib==3.0.1
 paho-mqtt==2.1.0
-sounddevice>=0.4.4
-pycaw==20240210
 pynput==1.8.1
 pyperclip==1.9.0
 pypinyin==0.53.0
-requests==2.32.3
-webrtcvad-wheels==2.0.14
+aiohttp==3.12.13
 websockets==11.0.3
 colorlog==6.9.0
-pygame==2.6.1
 qasync==0.27.1
 py-machineid==0.8.0
-aiohttp==3.12.13
-soxr==0.5.0.post1
-psutil==7.0.0
 mutagen==1.47.0
 beautifulsoup4==4.12.3
 brotli==1.1.0
 python-dateutil==2.9.0.post0
-PyQt5==5.15.11
-opencv-python-headless==4.11.0.86
-pendulum==3.1.0
 lunar_python==1.4.4
 tzdata
-sherpa-onnx==1.12.8
 pyinstaller==6.15.0
 rich==14.1.0
-requests==2.32.3
 packaging==25.0
-pillow==11.3.0


### PR DESCRIPTION
- 在requirements.txt和requirements_mac.txt中添加了平台特定的依赖项，确保在不同操作系统上正确安装所需库。
- 更新文档，提供更清晰的依赖安装指南，建议先安装系统依赖再安装Python包。