### PR TITLE
Add pywin32 to Windows-specific requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Windows-only
 comtypes==1.4.6; sys_platform == "win32"
 pycaw==20240210; sys_platform == "win32"
+pywin32==306; sys_platform == "win32"
 
 # 二进制/系统库敏感
 cryptography==44.0.1


### PR DESCRIPTION
Included pywin32 version 306 in requirements.txt for Windows platforms to ensure necessary dependencies are available.   不然不能播放声音