### PR TITLE
Fix pip install failed to run on windows platform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Windows-only
+﻿# Windows-only
 comtypes==1.4.6; sys_platform == "win32"
 pycaw==20240210; sys_platform == "win32"
 


### PR DESCRIPTION
```
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 125: character maps to <undefined>
```

update requirements.txt encoding