### PR TITLE
fix(ci): Windows 构建步骤强制使用 bash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,8 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build package
-        run: uv run unifypy . --config build.json --version ${{ steps.version.outputs.version }} --verbose
+        shell: bash
+        run: uv run unifypy . --config build.json --version ${{ steps.version.outputs.version }} --verbose 2>&1
 
       - name: Rename artifact with platform suffix
         shell: bash


### PR DESCRIPTION
## Summary
- Build package 步骤加 `shell: bash` + `2>&1`，修复 Windows PowerShell 吞掉 stderr 导致 unifypy 报错无输出的问题

## Context
v2.0.0 构建中 Windows job 失败，unifypy 1 秒退出但没有任何错误信息输出