### PR TITLE
fix(ci): Windows 使用 python -m unifypy 替代直接调用

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Build package
         shell: bash
-        run: uv run unifypy . --config build.json --version ${{ steps.version.outputs.version }} --verbose 2>&1
+        run: uv run python -m unifypy . --config build.json --version ${{ steps.version.outputs.version }} --verbose
 
       - name: Rename artifact with platform suffix
         shell: bash


### PR DESCRIPTION
unifypy CLI 入口在 Windows Git Bash 下静默退出码1无输出，改用 python -m unifypy 暴露完整 traceback。