### PR TITLE
fix(ci): Windows 调试 unifypy 启动失败

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,9 +74,30 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Build package
+      - name: Debug unifypy import (Windows only)
+        if: runner.os == 'Windows'
         shell: bash
-        run: uv run python -m unifypy . --config build.json --version ${{ steps.version.outputs.version }} --verbose
+        run: |
+          uv run python -c "
+          import sys, traceback
+          try:
+              from unifypy.cli import main
+              sys.argv = ['unifypy', '.', '--config', 'build.json', '--version', '${{ steps.version.outputs.version }}', '--verbose']
+              main()
+          except SystemExit as e:
+              print(f'SystemExit: {e.code}')
+              if e.code != 0:
+                  traceback.print_exc()
+                  sys.exit(e.code)
+          except Exception:
+              traceback.print_exc()
+              sys.exit(1)
+          "
+
+      - name: Build package
+        if: runner.os != 'Windows'
+        shell: bash
+        run: uv run unifypy . --config build.json --version ${{ steps.version.outputs.version }} --verbose
 
       - name: Rename artifact with platform suffix
         shell: bash


### PR DESCRIPTION
Windows 上 unifypy 静默退出无输出，添加 Python 级 try/except 暴露完整 traceback。非 Windows 平台不受影响。