### PR TITLE
fix(ci): uv run --no-sync 防止 unifypy 被卸载

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Build package
         shell: bash
         run: |
-          uv run unifypy . \
+          uv run --no-sync unifypy . \
             --config build.json \
             --version ${{ steps.version.outputs.version }} \
             --verbose


### PR DESCRIPTION
根因：uv run 默认 sync 会把不在 uv.lock 里的 unifypy 卸掉，导致静默 exit 1。加 --no-sync 修复。