### PR TITLE
fix(ci): ISCC 验证步骤改用 where.exe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,8 +82,8 @@ jobs:
 
       - name: Verify Inno Setup (Windows)
         if: runner.os == 'Windows'
-        shell: cmd
-        run: ISCC.exe /? || echo "ISCC not found"
+        shell: bash
+        run: where.exe ISCC.exe && echo "Inno Setup found"
 
       - name: Build package
         shell: bash


### PR DESCRIPTION
ISCC.exe /? 虽然打印帮助但退出码为1，导致 Windows job 在验证步骤就失败了，从未到达 Build package。改用 where.exe ISCC.exe 验证。