### PR TITLE
fix(ci): Windows PYTHONIOENCODING=utf-8 修复编码崩溃

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Build package
         shell: bash
+        env:
+          PYTHONIOENCODING: utf-8
         run: |
           uv run --no-sync unifypy . \
             --config build.json \


### PR DESCRIPTION
Windows Git Bash + rich 中文/emoji 输出导致 Python 编码崩溃静默 exit 1。设置 PYTHONIOENCODING=utf-8 修复。