### PR TITLE
fix(ci): 修复产物路径 installer/

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,16 +15,16 @@ jobs:
         include:
           - os: macos-latest
             platform: macos-arm64
-            artifact: "dist/installer/*.dmg"
+            artifact: "installer/*.dmg"
           - os: windows-latest
             platform: windows-x64
-            artifact: "dist/installer/*.exe"
+            artifact: "installer/*.exe"
           - os: ubuntu-24.04
             platform: linux-x64
-            artifact: "dist/installer/*.deb"
+            artifact: "installer/*.deb"
           - os: ubuntu-24.04-arm
             platform: linux-arm64
-            artifact: "dist/installer/*.deb"
+            artifact: "installer/*.deb"
 
     runs-on: ${{ matrix.os }}
     name: Build (${{ matrix.platform }})


### PR DESCRIPTION
unifypy 输出到 installer/ 不是 dist/installer/，导致 glob 匹配不到文件，Release 没有安装包。