### PR TITLE
fix(win): locale UTF-8 修复源码运行编码问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,17 @@
 import argparse
 import asyncio
+import locale
 import os
 import signal
 import sys
+
+# Windows: 强制 C/C++ 运行时使用 UTF-8，解决 sherpa-onnx 读取声调拼音文件乱码
+if sys.platform == "win32":
+    os.environ["PYTHONIOENCODING"] = "utf-8"
+    try:
+        locale.setlocale(locale.LC_ALL, ".UTF-8")
+    except locale.Error:
+        pass
 
 os.environ["QSG_RHI_BACKEND"] = "opengl"
 # 强制 qasync 使用 PySide6


### PR DESCRIPTION
补充源码运行时的 UTF-8 修复。locale.setlocale(LC_ALL, '.UTF-8') 设置 C 运行时 locale，与 manifest（打包后生效）配合覆盖所有场景。