### PR TITLE
fix(ci): 移除 mt.exe manifest 嵌入步骤

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,15 +121,6 @@ jobs:
             --verbose \
             --clean
 
-      - name: Embed UTF-8 manifest into Windows exe
-        if: runner.os == 'Windows'
-        shell: cmd
-        run: |
-          for /r dist %%f in (xiaozhi.exe) do (
-            echo Embedding manifest into %%f
-            mt.exe -manifest assets\xiaozhi.manifest -outputresource:"%%f;#1"
-          )
-
       - name: Rename artifact with platform suffix
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- 移除 Windows CI 中 mt.exe 嵌入 manifest 的步骤，该步骤因 mt.exe 不在 PATH 导致构建失败
- tokens.txt 编码问题已通过 `_ensure_ascii_path` 在 Python 层修复，不再需要进程级 manifest

## Test plan
- [ ] CI Windows 构建通过