### PR TITLE
fix(audio+protocol): 修复多声道下混失败 + 禁用自动重连

### DIFF
--- a/src/audio_codecs/audio_codec.py
+++ b/src/audio_codecs/audio_codec.py
@@ -127,12 +127,10 @@ class AudioCodec:
             return
 
         try:
-            # indata 已经是 float32，范围 [-1.0, 1.0]
-            audio_float32 = indata.flatten()
-
             # 1. 格式转换（下混 + 重采样）
+            # 保留 indata 的 (frames, channels) 形状，让 downmix_to_mono 正确下混
             audio_converted = self.converter.convert_input(
-                audio_float32, AudioConfig.INPUT_FRAME_SIZE
+                indata, AudioConfig.INPUT_FRAME_SIZE
             )
             if audio_converted is None:
                 return  # 数据不足，等待下一帧

--- a/src/protocols/protocol.py
+++ b/src/protocols/protocol.py
@@ -24,7 +24,7 @@ class Protocol:
         self._is_closing = False
         self._reconnect_attempts = 0
         self._max_reconnect_attempts = 5  # 默认重连5次
-        self._auto_reconnect_enabled = True  # 默认启用自动重连
+        self._auto_reconnect_enabled = False  # 默认禁用自动重连
         self._connection_monitor_task = None
 
     def on_incoming_json(self, callback):


### PR DESCRIPTION
## Summary
- 修复 `_input_callback` 中 `indata.flatten()` 破坏声道结构导致 `downmix_to_mono` 无法下混的 bug（Windows 多声道设备上 20ms 麦克风不录、60ms 播放卡顿）
- 默认禁用自动重连，避免首次 WebSocket 超时后重连循环阻塞 UI

## Test plan
- [ ] Windows 多声道设备 20ms 帧长度下麦克风正常录音
- [ ] Windows 60ms 帧长度下播放不卡顿
- [ ] 连接失败后不自动重连，UI 不阻塞