### PR TITLE
fix(ws+activation): 禁用 websockets 代理自动检测 + 改善错误日志

### DIFF
--- a/src/activation/service.py
+++ b/src/activation/service.py
@@ -165,7 +165,7 @@ class ActivationService:
             return result
 
         except Exception as e:
-            self.logger.error(f"系统初始化失败: {e}")
+            self.logger.error(f"系统初始化失败: {type(e).__name__}: {e}", exc_info=True)
             return ActivationResult(
                 success=False,
                 need_activation_ui=False,

--- a/src/protocols/websocket_protocol.py
+++ b/src/protocols/websocket_protocol.py
@@ -67,11 +67,13 @@ class WebsocketProtocol(Protocol):
                     uri=self.WEBSOCKET_URL,
                     ssl=current_ssl_context,
                     additional_headers=self.HEADERS,
-                    ping_interval=20,  # 使用websockets自己的心跳，20秒间隔
-                    ping_timeout=20,  # ping超时20秒
-                    close_timeout=10,  # 关闭超时10秒
-                    max_size=10 * 1024 * 1024,  # 最大消息10MB
-                    compression=None,  # 禁用压缩以提高稳定性
+                    ping_interval=20,
+                    ping_timeout=20,
+                    close_timeout=10,
+                    open_timeout=5,
+                    max_size=10 * 1024 * 1024,
+                    compression=None,
+                    proxy=None,
                 )
             except TypeError:
                 # 旧的写法 (在较早的Python版本中)
@@ -79,11 +81,12 @@ class WebsocketProtocol(Protocol):
                     self.WEBSOCKET_URL,
                     ssl=current_ssl_context,
                     extra_headers=self.HEADERS,
-                    ping_interval=20,  # 使用websockets自己的心跳
-                    ping_timeout=20,  # ping超时20秒
-                    close_timeout=10,  # 关闭超时10秒
-                    max_size=10 * 1024 * 1024,  # 最大消息10MB
-                    compression=None,  # 禁用压缩
+                    ping_interval=20,
+                    ping_timeout=20,
+                    close_timeout=10,
+                    open_timeout=5,
+                    max_size=10 * 1024 * 1024,
+                    compression=None,
                 )
 
             # 启动消息处理循环（保存任务引用，关闭时可取消）


### PR DESCRIPTION
## Summary
- websockets 15.x 默认 `proxy=True` 在 Windows 上自动检测系统代理，导致首次连接卡 10 秒。添加 `proxy=None` + `open_timeout=5`
- 激活失败日志补充异常类型和 traceback，避免空消息无法定位

## Test plan
- [ ] Windows 首次 WebSocket 连接不再卡 10 秒
- [ ] 打包版如仍失败，error.log 能看到完整异常信息