### PR TITLE
fix(win): FFmpeg 子进程隐藏控制台窗口 + v2.0.3

### DIFF
--- a/src/audio_codecs/music_decoder.py
+++ b/src/audio_codecs/music_decoder.py
@@ -1,5 +1,6 @@
 import asyncio
 import subprocess
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -9,6 +10,10 @@ from src.logging import get_logger
 from src.utils.resource_finder import get_ffmpeg_path, get_ffprobe_path
 
 logger = get_logger()
+
+_SUBPROCESS_KW = (
+    {"creationflags": subprocess.CREATE_NO_WINDOW} if sys.platform == "win32" else {}
+)
 
 
 class MusicDecoder:
@@ -31,6 +36,7 @@ class MusicDecoder:
                     "-version",
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
+                    **_SUBPROCESS_KW,
                 )
             except FileNotFoundError:
                 logger.warning("ffprobe 未安装，无法获取音频时长")
@@ -49,7 +55,7 @@ class MusicDecoder:
             ]
 
             process = await asyncio.create_subprocess_exec(
-                *cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                *cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **_SUBPROCESS_KW
             )
 
             stdout, stderr = await process.communicate()
@@ -92,6 +98,7 @@ class MusicDecoder:
                     "-version",
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
+                    **_SUBPROCESS_KW,
                 )
                 await result.wait()
             except FileNotFoundError:
@@ -120,7 +127,7 @@ class MusicDecoder:
             )
 
             self._process = await asyncio.create_subprocess_exec(
-                *cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                *cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **_SUBPROCESS_KW
             )
 
             # 启动读取任务

--- a/src/constants/system.py
+++ b/src/constants/system.py
@@ -21,7 +21,7 @@ class SystemConstants:
     # 应用信息
     APP_NAME = "py-xiaozhi"  # 程序标识名（用于目录、配置等）
     APP_DISPLAY_NAME = "py-xiaozhi"  # 显示名称（用于窗口标题、UI等）
-    APP_VERSION = "2.0.2"
+    APP_VERSION = "2.0.3"
     BOARD_TYPE = "bread-compact-wifi"
 
     # 默认超时设置

--- a/src/utils/activation_announcer.py
+++ b/src/utils/activation_announcer.py
@@ -53,10 +53,17 @@ class ActivationAnnouncer:
                 "-"
             ]
 
+            import sys
+
+            popen_kw = {}
+            if sys.platform == "win32":
+                popen_kw["creationflags"] = subprocess.CREATE_NO_WINDOW
+
             self._process = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
+                **popen_kw,
             )
 
             stdout, stderr = self._process.communicate(timeout=10)


### PR DESCRIPTION
## Summary
- Windows 上 FFmpeg/ffprobe 子进程添加 `CREATE_NO_WINDOW`，消除 CMD 黑窗闪烁
- 涉及 `music_decoder.py` (4处) + `activation_announcer.py` (1处)
- Bump v2.0.3

## Test plan
- [ ] Windows 播放音乐时不再闪 CMD 黑窗
- [ ] macOS/Linux 不受影响