### PR TITLE
fix(ci): 拷贝真实 FFmpeg 二进制而非 Chocolatey shim

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,8 +100,16 @@ jobs:
           DEST="libs/ffmpeg/${PLAT}/${ARCH}"
           mkdir -p "$DEST"
           if [ "$RUNNER_OS" = "Windows" ]; then
-            cp "$(which ffmpeg.exe)" "$DEST/ffmpeg.exe"
-            cp "$(which ffprobe.exe)" "$DEST/ffprobe.exe"
+            # Chocolatey shim (~384KB) 不是真实二进制，需要找到实际安装路径
+            CHOCO_FFMPEG="C:/ProgramData/chocolatey/lib/ffmpeg/tools/ffmpeg/bin"
+            if [ -f "$CHOCO_FFMPEG/ffmpeg.exe" ]; then
+              cp "$CHOCO_FFMPEG/ffmpeg.exe" "$DEST/ffmpeg.exe"
+              cp "$CHOCO_FFMPEG/ffprobe.exe" "$DEST/ffprobe.exe"
+            else
+              echo "WARNING: Chocolatey FFmpeg bin not found at $CHOCO_FFMPEG, falling back to shim"
+              cp "$(which ffmpeg.exe)" "$DEST/ffmpeg.exe"
+              cp "$(which ffprobe.exe)" "$DEST/ffprobe.exe"
+            fi
           else
             cp "$(which ffmpeg)" "$DEST/ffmpeg"
             cp "$(which ffprobe)" "$DEST/ffprobe"


### PR DESCRIPTION
## Summary
- CI 之前用 `which ffmpeg.exe` 拷贝的是 Chocolatey shim (384KB)，不是真实二进制
- shim 在用户机器上找不到目标 FFmpeg → 音乐解码静默失败（buffer size 错误）
- 改为从 Chocolatey 安装路径直接拷贝真实二进制

## Test plan
- [ ] 打包版播放音乐正常
- [ ] `ls -lh` 验证 ffmpeg.exe 不再是 384KB