### PR TITLE
fix(win32): 修复 Windows 端 4 个已知问题

### DIFF
--- a/src/audio_codecs/audio_codec.py
+++ b/src/audio_codecs/audio_codec.py
@@ -292,7 +292,9 @@ class AudioCodec:
         Args:
             pcm_float32: float32 PCM 数据
         """
-        await self.output_buffer.put(pcm_float32, replace_oldest=False)
+        # replace_oldest=True：输出队列满时丢弃旧帧而非阻塞，
+        # 防止播放回路卡死在 put() 导致 decoder 超时刷屏
+        await self.output_buffer.put(pcm_float32, replace_oldest=True)
 
     async def clear_audio_queue(self):
         """清空音频队列"""

--- a/src/bootstrap/container.py
+++ b/src/bootstrap/container.py
@@ -347,19 +347,6 @@ class ServiceContainer:
 
     async def _on_audio_channel_closed(self, _=None) -> None:
         await self.state.set_device_state(DeviceState.IDLE)
-        await self._stop_music_on_disconnect()
-
-    async def _stop_music_on_disconnect(self) -> None:
-        """连接断开时停止音乐播放，防止解码器无限输出超时日志."""
-        try:
-            from src.mcp.tools.music.music_player import get_music_player_instance
-
-            music_player = get_music_player_instance()
-            if music_player.is_playing:
-                await music_player.stop()
-                logger.debug("连接断开，已停止音乐播放")
-        except Exception as e:
-            logger.debug(f"连接断开时停止音乐失败: {e}")
 
     async def _on_network_error(self, error_message: str = None) -> None:
         self.state.set_keep_listening(False)

--- a/src/bootstrap/container.py
+++ b/src/bootstrap/container.py
@@ -347,6 +347,19 @@ class ServiceContainer:
 
     async def _on_audio_channel_closed(self, _=None) -> None:
         await self.state.set_device_state(DeviceState.IDLE)
+        await self._stop_music_on_disconnect()
+
+    async def _stop_music_on_disconnect(self) -> None:
+        """连接断开时停止音乐播放，防止解码器无限输出超时日志."""
+        try:
+            from src.mcp.tools.music.music_player import get_music_player_instance
+
+            music_player = get_music_player_instance()
+            if music_player.is_playing:
+                await music_player.stop()
+                logger.debug("连接断开，已停止音乐播放")
+        except Exception as e:
+            logger.debug(f"连接断开时停止音乐失败: {e}")
 
     async def _on_network_error(self, error_message: str = None) -> None:
         self.state.set_keep_listening(False)

--- a/src/mcp/tools/music/music_player.py
+++ b/src/mcp/tools/music/music_player.py
@@ -802,6 +802,21 @@ class MusicPlayer:
         try:
             self._current_file_path = file_path
 
+            # 先停止旧 decoder，防止残留任务继续写入队列
+            if self.decoder:
+                await self.decoder.stop()
+                self.decoder = None
+
+            # 取消旧的播放循环，防止多个 loop 并发读取同一队列
+            if self._playback_task and not self._playback_task.done():
+                self._playback_task.cancel()
+                try:
+                    await self._playback_task
+                except asyncio.CancelledError:
+                    pass
+                finally:
+                    self._playback_task = None
+
             cleared = await self._clear_music_queue()
             if cleared > 0:
                 logger.debug(f"开始播放前清空 {cleared} 帧音乐数据")
@@ -1082,6 +1097,15 @@ class MusicPlayer:
             if self.decoder:
                 await self.decoder.stop()
                 self.decoder = None
+
+            if self._playback_task and not self._playback_task.done():
+                self._playback_task.cancel()
+                try:
+                    await self._playback_task
+                except asyncio.CancelledError:
+                    pass
+                finally:
+                    self._playback_task = None
 
             self.is_playing = False
             self.paused = False

--- a/src/utils/activation_announcer.py
+++ b/src/utils/activation_announcer.py
@@ -8,6 +8,8 @@ import threading
 from pathlib import Path
 
 import numpy as np
+
+from src.utils.resource_finder import get_ffmpeg_path
 import sounddevice as sd
 
 from src.logging import get_logger
@@ -44,7 +46,7 @@ class ActivationAnnouncer:
         """使用 ffmpeg 解码音频文件."""
         try:
             cmd = [
-                "ffmpeg",
+                get_ffmpeg_path(),
                 "-i", str(file_path),
                 "-f", "s16le",      # 16位小端 PCM
                 "-ar", "24000",     # 采样率

--- a/src/utils/audio_device.py
+++ b/src/utils/audio_device.py
@@ -83,8 +83,8 @@ class AudioDeviceManager:
             if not output_info:
                 raise RuntimeError("无法找到可用的输出设备")
 
-        # 3. 使用设备报告的声道数（不再限制，避免 9997 错误）
-        input_channels = input_info["channels"]
+        # 3. 输入固定单声道（协议要求 + 避免阵列驱动延迟），输出保持设备声道数
+        input_channels = 1
         output_channels = output_info["channels"]
 
         device_input_sample_rate = input_info["sample_rate"]


### PR DESCRIPTION
1. audio_device: 输入固定 1ch，避免 Intel SST 阵列 4ch 模式下驱动 DSP 处理增加 ~40ms 延迟，同时仍支持所有设备 (PortAudio 兜底转换)

2. activation_announcer: 使用 get_ffmpeg_path() 替代裸 'ffmpeg' 命令， 修复打包版无法找到内置 FFmpeg 导致激活语音播报失败的问题

3. container: 音频通道关闭时自动停止音乐播放器，修复断连后 music_decoder 无限输出队列超时日志的问题

4. music_player: _start_playback 和 _handle_playback_finished 中添加 旧 decoder/playback_task 清理逻辑，修复 pause/resume 并发泄漏和 歌曲自然播完后 task 残留的问题