### PR TITLE
docs: 修复 README Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ python main.py --protocol mqtt       # MQTT protocol
 
 ## Project Statistics
 
-[![Star History Chart](https://api.star-history.com/svg?repos=huangjunsen0406/py-xiaozhi&type=Date)](https://www.star-history.com/#huangjunsen0406/py-xiaozhi&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=huangjunsen0406/py-xiaozhi&type=Date)](https://star-history.dera.page/#huangjunsen0406/py-xiaozhi&Date)
 
 ## License
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -184,7 +184,7 @@ py-xiaozhi/
 
 ## 项目统计
 
-[![Star History Chart](https://api.star-history.com/svg?repos=huangjunsen0406/py-xiaozhi&type=Date)](https://www.star-history.com/#huangjunsen0406/py-xiaozhi&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=huangjunsen0406/py-xiaozhi&type=Date)](https://star-history.dera.page/#huangjunsen0406/py-xiaozhi&Date)
 
 ## 许可证
 


### PR DESCRIPTION
README 中的 Star History 图表当前已无法正常显示，原因是 GitHub stargazer API 的限制。

本 MR 将图表切换到新的数据源与域名，同时更新 README.md 与 README.zh.md 中的链接，使项目统计图表恢复可用。